### PR TITLE
[Chore] Add JetBrains IDEs Files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ dist/
 node_modules/
 .env
 *.lock
+
+# JetBrains IDEs
+.idea/


### PR DESCRIPTION
# Summary

Add files generated by JetBrains IDEs files to `.gitignore`

## Changes

- Add `./idea` to `.gitignore` to better avoid committing local JetBrains IDE configs to the repo. 
- Clone PR to [[Chore] Add JetBrains IDEs Files to .gitignore](https://github.com/game-by-virtuals/game-python/pull/81) in [Python repo](https://github.com/game-by-virtuals/game-python).

## Dev Testing

- Screenshots
  | Before | After |
  | --- | --- |
  | <img width="958" alt="image" src="https://github.com/user-attachments/assets/8f7f90c2-9bd3-44d2-8ed7-4d9ab4997bdf" /> | <img width="958" alt="image" src="https://github.com/user-attachments/assets/26e64142-39b6-46ff-8f47-79a0b744d552" /> |
