### PR TITLE
fix(Enso plugin): Increase gas by 50% from Enso API

### DIFF
--- a/plugins/ensoPlugin/README.md
+++ b/plugins/ensoPlugin/README.md
@@ -39,6 +39,8 @@ yarn add @virtuals-protocol/game-enso-plugin
 
 1. Make sure the .env variables are set
 
+Get your Enso API key [here](https://shortcuts.enso.finance/developers)
+
 ```
 WALLET_PRIVATE_KEY=
 RPC_PROVIDER_URL=

--- a/plugins/ensoPlugin/package.json
+++ b/plugins/ensoPlugin/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^22.13.9",
     "dotenv": "^16.4.7",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.2"

--- a/plugins/ensoPlugin/src/ensoPlugin.ts
+++ b/plugins/ensoPlugin/src/ensoPlugin.ts
@@ -176,6 +176,8 @@ function ensoRoute(params: IEnsoFunctionParams) {
           account: params.wallet.account,
           data: routeData.tx.data as Address,
           to: routeData.tx.to,
+          // Increase gas from Enso API by 50% (to prevent out-of-gas errors)
+          gas: (BigInt(routeData.gas) * BigInt(15)) / BigInt(10),
           value: BigInt(routeData.tx.value),
         });
 


### PR DESCRIPTION
This fixes issue where transaction might revert with out-of-gas.

Test [transaction on Base](https://basescan.org/tx/0xeba80b6340a1c8a9588624ee94b9190aeab14073bdc8afb41d740133a5f21a1c)to make sure it works 