### PR TITLE
game-starter: Revamp TEE instructions

### DIFF
--- a/game-starter/README.md
+++ b/game-starter/README.md
@@ -24,13 +24,70 @@ NPM: https://www.npmjs.com/package/@virtuals-protocol/game
     `docker compose up -d`
 **Note** We recommend using nvm version 23 `nvm use 23`
 
-## To run project in Phala TEE
+## To run project in TEE
+
+### Phala
 
 1. Build the docker image and publish it to the docker hub
-    `docker compose build -t <your-dockerhub-username>/virtuals-game-starter`
+   
+    `docker compose build -t <your-dockerhub-username>/virtuals-game-starter .`
+
     `docker push <your-dockerhub-username>/virtuals-game-starter`
+
 2. Deploy to Phala cloud using [tee-cloud-cli](https://github.com/Phala-Network/tee-cloud-cli) or manually with the [Cloud dashboard](https://cloud.phala.network/).
+
 3. Check your agent's TEE proof and verify it on the [TEE Attestation Explorer](https://proof.t16z.com/).
 
+### Oasis ROFL
 
+1. To ROFLize your agent, get the [Oasis CLI](https://github.com/oasisprotocol/cli/releases)
+   for your OS of choice.
 
+2. Register a new ROFL app and encrypt the secrets inside the `rofl.yaml`
+   manifest file:
+   
+     ```shell
+     oasis rofl create
+     echo -n "your_game_api_key_here" | oasis rofl secret set API_KEY -
+     echo -n "your_openai_api_key_here" | oasis rofl secret set OPENAI_API_KEY -
+     echo -n "your_weather_api_key_here" | oasis rofl secret set WEATHER_API_KEY -
+     ```
+
+3. Build the docker image and publish it, for example:
+   
+   ```shell
+   docker build -t docker.io/<your-dockerhub-username>/virtuals-game-starter .
+   docker push docker.io/<your-dockerhub-username>/virtuals-game-starter
+   ```
+   
+   In `rofl-compose.yml` replace `<your-dockerhub-username>` with your actual
+   one. To ensure integrity, we strongly suggest to hardcode the image hash reported
+   when you pushed the image. For example:
+   
+   ```yaml
+   services:
+     game-starter:
+       image: docker.io/rosy/virtuals-game-starter@sha256:25263747e8f9ebc193e403ac009b696ea49459d9d642b86d890de432dae4469f
+   ```
+   
+4. Build the bundle, submit the obtained Enclave ID and the secrets to
+   the chain and deploy it:
+   
+   ```shell
+   oasis rofl build
+   oasis rofl update
+   oasis rofl deploy
+   ```
+   
+5. To check that your ROFL instance is up running and review the TEE proof run:
+   
+   `oasis rofl show`
+   
+   To independently verify whether the source in front of you matches the
+   deployed version of ROFL on-chain invoke:
+   
+   `oasis rofl build --verify`
+
+Visit https://docs.oasis.io/build/rofl/ for documentation. Should you have
+any questions reach out to us on #dev-central Discord channel at
+https://oasis.io/discord.

--- a/game-starter/rofl-compose.yml
+++ b/game-starter/rofl-compose.yml
@@ -1,0 +1,17 @@
+services:
+  game-starter:
+    image: docker.io/<your-dockerhub-username>/virtuals-game-starter
+    build:
+      context: .
+      dockerfile: Dockerfile
+    platform: linux/amd64
+    environment:
+      - API_KEY=${API_KEY}
+      - WEATHER_API_KEY=${WEATHER_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+    volumes:
+      - virtuals:/app
+    restart: always
+
+volumes:
+    virtuals:

--- a/game-starter/rofl.yaml
+++ b/game-starter/rofl.yaml
@@ -1,0 +1,17 @@
+name: game-starter
+version: 0.1.0
+tee: tdx
+kind: container
+resources:
+  memory: 512
+  cpus: 1
+  storage:
+    kind: disk-persistent
+    size: 10000
+artifacts:
+  firmware: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.4.1/ovmf.tdx.fd#db47100a7d6a0c1f6983be224137c3f8d7cb09b63bb1c7a5ee7829d8e994a42f
+  kernel: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.4.1/stage1.bin#06e12cba9b2423b4dd5916f4d84bf9c043f30041ab03aa74006f46ef9c129d22
+  stage2: https://github.com/oasisprotocol/oasis-boot/releases/download/v0.4.1/stage2-podman.tar.bz2#6f2487aa064460384309a58c858ffea9316e739331b5c36789bb2f61117869d6
+  container:
+    runtime: https://github.com/oasisprotocol/oasis-sdk/releases/download/rofl-containers%2Fv0.4.2/rofl-containers#0cbaa4c0c1b35c5ed41156868bee9f3726f52eeedc01b3060d3b2eb67d76f546
+    compose: rofl-compose.yml


### PR DESCRIPTION
# Summary

Revamps the TEE chapter for deploying agents.

## Changes

This PR extends the TEE chapter:
1. Fixes Phala build command (missing trailing `.`), correct markdown formatting
2. Adds Oasis ROFL deployment steps

## Related Changes

| Description | PR |
| --- | --- |
| The initial version of the TEE agent deployment chapter, Phala-only | #61 |

## Dev Testing

https://github.com/user-attachments/assets/2067f926-89bc-43b3-b1e9-8537d140f859

