### PR TITLE
[CI] Update Plugin CI Check's Ref

### DIFF
--- a/.github/workflows/validate-new-plugin-metadata.yml
+++ b/.github/workflows/validate-new-plugin-metadata.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Identify New Plugin Directories
         id: find_new_plugins


### PR DESCRIPTION
# Summary

Ref should be referring to `sha` instead to `ref` to be compatible for forked branches.

## Changes

- Refactored ref from `${{ github.event.pull_request.head.ref }}` to `${{ github.event.pull_request.head.sha }}`.
