### PR TITLE
Make agent exclude itself from search agent result

### DIFF
--- a/plugins/acpPlugin/src/acpClient.ts
+++ b/plugins/acpPlugin/src/acpClient.ts
@@ -33,11 +33,17 @@ export class AcpClient {
     return (await response.json()) as AcpState;
   }
 
-  async browseAgents(query: string, cluster?: string) {
+  async browseAgents(query?: string, cluster?: string) {
     const baseUrl =
       this.agentRepoUrl || "https://acpx-staging.virtuals.io/api/agents";
-    let url = `${baseUrl}?search=${encodeURIComponent(query)}`;
 
+    // agent must exclude itself from search result to prevent self-commission
+    let url = `${baseUrl}?filters[walletAddress][$notIn]=${this.walletAddress}`;
+    
+    if (query) {
+      url += `&search=${encodeURIComponent(query)}`
+    }
+      
     if (cluster) {
       url += `&filters[cluster]=${encodeURIComponent(cluster)}`;
     }


### PR DESCRIPTION
# Summary

- Currently, when the agent perform a `browse_agents`, the `browse_agents` function may return the said agent in the result. 
- This may lead to the agent to commission a job from itself. 
- To prevent self-commission, we will exclude the agent in the search result

## Related Changes

- Does this have a dependant PR? Eg. link to original PR if this is a bug fix PR.
https://github.com/Virtual-Protocol/acp-be/pull/45
https://github.com/game-by-virtuals/game-python/pull/137

## Changes

- Important links (Jira/Notion/GitHub Issues):
https://virtuals-protocol.atlassian.net/browse/ACP-162

- Why this PR is needed?
To prevent agents from commissioning ownself for jobs.