### PR TITLE
[ACP Plugin][Docs] Add onEvaluate Examples and jobExpiryDurationMins Setup to READMEs

### DIFF
--- a/plugins/acpPlugin/README.md
+++ b/plugins/acpPlugin/README.md
@@ -137,6 +137,20 @@ const agent = new GameAgent("<your-GAME-api-key-here>", {
 ```
 
 5. (optional) If you want to listen to the onEvaluate event, you can implement the onEvaluate function.
+
+Evaluation refers to the process where buyer agent reviews the result submitted by the seller and decides whether to accept or reject it.
+This is where the `on_evaluate` function comes into play. It allows your agent to programmatically verify deliverables and enforce quality checks.
+
+🔍 **Example implementations can be found in:**
+
+Use Cases:
+- Basic always-accept evaluation
+- URL and file validation examples
+
+Source Files:
+- [example/agentic/README.md](example/agentic/README.md)
+- [example/reactive/README.md](example/reactive/README.md)
+
 ```typescript
 const onEvaluate = (deliverable: IDeliverable) => {
   // Implement your evaluation logic here

--- a/plugins/acpPlugin/example/agentic/README.md
+++ b/plugins/acpPlugin/example/agentic/README.md
@@ -104,7 +104,7 @@ If you're building a buyer agent that carries out self-evaluation, you’ll need
 function onEvaluate(deliverable) {
   console.log("Evaluating deliverable:", deliverable);
   // In this example, we auto-accept all deliverables
-  return [true, "Meme accepted"];
+  resolve(new EvaluateResult(true, "Meme accepted"));
 }
 ```
 Then, pass this function into the plugin:
@@ -255,11 +255,6 @@ const acpPlugin = new AcpPlugin({
 In this example:
 - Any job created through this plugin instance will be automatically marked as expired after 10 minutes, unless a response is received. 
 - You can adjust this value (e.g., to 5 or 30) based on how responsive your agent network is.
-
-### Best Practices ✅
-- Shorter durations (e.g., 5–10 mins) are ideal for time-sensitive jobs or real-time commerce flows. 
-- Longer durations (e.g., 30–60 mins) may suit batch processing or coordination workflows involving multiple agents. 
-- Ensure all agents in your system respect the `expiredAt` value and avoid executing expired jobs.
 
 ---
 

--- a/plugins/acpPlugin/example/agentic/README.md
+++ b/plugins/acpPlugin/example/agentic/README.md
@@ -75,6 +75,193 @@ Run seller
 ```bash
 npx ts-node example/seller.ts
 ```
+---
+
+## Understanding the `onEvaluate` Function
+
+The `onEvaluate` parameter in the AcpPlugin configuration is crucial for real-time communication between agents during the evaluation phase of a transaction:
+
+- When the evaluator address matches the buyer's address, it establishes a socket connection
+- This connection emits an event on `SocketEvents["ON_EVALUATE"]`
+- The event prompts the user to validate the product/result and make a decision
+- Users can either approve the result (completing the transaction) or reject it (canceling the transaction)
+- Example implementation:
+
+```bash
+const onEvaluate = (deliverable: IDeliverable) => {
+  return new Promise<EvaluateResult>((resolve) => {
+    console.log(deliverable);
+    resolve(new EvaluateResult(true, "This is a test reasoning"));
+  });
+};
+```
+### How it works?
+Here’s a minimal example to get started with evaluation.
+
+If you're building a buyer agent that carries out self-evaluation, you’ll need to define an `onEvaluate` callback when initializing the AcpPlugin. This function will be triggered when the agent receives a deliverable to review.
+
+```bash
+function onEvaluate(deliverable) {
+  console.log("Evaluating deliverable:", deliverable);
+  // In this example, we auto-accept all deliverables
+  return [true, "Meme accepted"];
+}
+```
+Then, pass this function into the plugin:
+```bash
+const options: AcpPluginOptions = {
+  apiKey: "your_api_key_here",
+  acpTokenClient: myTokenClient,
+  onEvaluate: onEvaluate
+};
+```
+
+### More realistic examples
+You can customize the logic:
+
+1️⃣ Example: Check url link exists:
+
+This function ensures that the submitted deliverable contains a valid URL by checking if it starts with either `http://` or `https://`.
+```bash
+import AcpPlugin, { EvaluateResult } from "@virtuals-protocol/game-acp-plugin";
+
+const acpPlugin = new AcpPlugin({
+  .
+  .
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable:", deliverable);
+    const url = deliverable?.value || "";
+
+    if (typeof url === "string" && (url.startsWith("http://") || url.startsWith("https://"))) {
+      console.log(`✅ URL link looks valid: ${url}`);
+      return new EvaluateResult(true, "URL link looks valid");
+    } else {
+      console.log(`❌ Invalid or missing URL: ${url}`);
+      return new EvaluateResult(false, "Invalid or missing URL");
+    }
+  }
+});
+}
+```
+
+Sample Output:
+```bash
+Evaluating deliverable: { type: 'url', value: 'https://example.com/resource' }
+✅ URL link looks valid: https://example.com/resource
+Evaluation Result: EvaluateResult { accepted: true, reason: 'URL link looks valid' }
+```
+
+2️⃣ Check File Extension (e.g. only allow `.png` or `.jpg` or `.jpeg`):
+```bash
+import AcpPlugin, { EvaluateResult } from '@virtuals-protocol/game-acp-plugin';
+
+const acpPlugin = new AcpPlugin({
+  .
+  .
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable:", deliverable);
+
+    const url: string = deliverable?.value || "";
+    const allowedExtensions = [".png", ".jpg", ".jpeg"];
+    const isAllowedFormat = allowedExtensions.some(ext => url.toLowerCase().endsWith(ext));
+
+    if (isAllowedFormat) {
+      console.log(`✅ Image format is allowed: ${url}`);
+      return new EvaluateResult(true, "Image format is allowed");
+    } else {
+      console.log(`❌ Unsupported image format — only PNG/JPG/JPEG are allowed: ${url}`);
+      return new EvaluateResult(false, "Unsupported image format — only PNG and JPG are allowed");
+    }
+  }
+});
+}
+```
+
+Sample Output:
+```bash
+Evaluating deliverable: { type: 'image', value: 'https://cdn.example.com/meme_final.jpg' }
+✅ Image format is allowed: https://cdn.example.com/meme_final.jpg
+Evaluation Result: EvaluateResult { accepted: true, reason: 'Image format is allowed' }
+```
+
+These are just simple, self-defined examples of custom evaluator logic. You’re encouraged to tweak and expand these based on the complexity of your use case. Evaluators are a powerful way to gatekeep quality and ensure consistency in jobs submitted by seller agents.
+
+👉 Moving forward, we are building four in-house evaluator agent clusters (work in progress):
+
+- Blockchain Evaluator Agent
+- Meme Evaluator Agent
+- Hedgefund Evaluator Agent
+- Mediahouse Evaluator Agent 
+
+These evaluators will handle more advanced logic and domain-specific validations. But feel free to build your own lightweight ones until they’re fully live!
+
+---
+
+## Understanding Clusters
+
+Clusters in ACP are categories that group agents together based on their functionality or domain:
+
+- `cluster`: Specifies the category your agent belongs to, making it easier for other agents to discover and interact with services in the same domain.
+- [WIP] `evaluator_cluster`: A specialized type of cluster specifically for agents that evaluate jobs generated by AI. These evaluator agents provide quality control and verification services.
+
+Clusters help with:
+
+- Organizing agents by their specialization
+- Improving service discovery efficiency
+- Creating ecosystems of complementary agents
+- Enabling targeted searches for specific capabilities
+
+When configuring your agent, choose clusters that accurately represent your agent's capabilities to ensure it can be found by the right counterparts.
+
+---
+
+## Job Expiry Setup with `jobExpiryDurationMins`
+
+The `jobExpiryDurationMins` parameter defines how long a job request remains active and valid before it automatically expires. This timeout is crucial for managing agent coordination workflows, especially in asynchronous or decentralized environments where job responses may not arrive immediately.
+
+### Why It Matters
+
+Setting an expiry time ensures that:
+- Stale or unresponsive job requests do not hang indefinitely
+- The system can safely discard or retry expired jobs
+
+### How It Works
+Internally, `jobExpiryDurationMins` is used to compute a future timestamp (expiredAt) relative to the current time:
+```bash
+const expiredAt = new Date();
+expiredAt.setMinutes(
+  expiredAt.getMinutes() + this.jobExpiryDurationMins
+);
+```
+
+### Example: Plugin Setup with Job Expiry
+```bash
+const acpPlugin = new AcpPlugin({
+  apiKey: "apt-xxx",
+  acpTokenClient: await AcpToken.build(
+    "0xAgentAddress",
+    1, // chainId
+    "0xUserWallet"
+  ),
+  cluster: "hedgefund",
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable", deliverable);
+    return new EvaluateResult(true, "custom evaluator");
+  },
+  jobExpiryDurationMins: 10, // Job will expire 10 minutes after creation
+});
+```
+
+In this example:
+- Any job created through this plugin instance will be automatically marked as expired after 10 minutes, unless a response is received. 
+- You can adjust this value (e.g., to 5 or 30) based on how responsive your agent network is.
+
+### Best Practices ✅
+- Shorter durations (e.g., 5–10 mins) are ideal for time-sensitive jobs or real-time commerce flows. 
+- Longer durations (e.g., 30–60 mins) may suit batch processing or coordination workflows involving multiple agents. 
+- Ensure all agents in your system respect the `expiredAt` value and avoid executing expired jobs.
+
+---
 
 ## Note
 - Make sure to replace placeholder API keys and private keys with your own

--- a/plugins/acpPlugin/example/reactive/README.md
+++ b/plugins/acpPlugin/example/reactive/README.md
@@ -233,7 +233,7 @@ If you're building a buyer agent that carries out self-evaluation, you’ll need
 function onEvaluate(deliverable) {
   console.log("Evaluating deliverable:", deliverable);
   // In this example, we auto-accept all deliverables
-  return [true, "Meme accepted"];
+  resolve(new EvaluateResult(true, "Meme accepted"));
 }
 ```
 Then, pass this function into the plugin:
@@ -384,12 +384,6 @@ const acpPlugin = new AcpPlugin({
 In this example:
 - Any job created through this plugin instance will be automatically marked as expired after 10 minutes, unless a response is received. 
 - You can adjust this value (e.g., to 5 or 30) based on how responsive your agent network is.
-
-### Best Practices ✅
-- Shorter durations (e.g., 5–10 mins) are ideal for time-sensitive jobs or real-time commerce flows. 
-- Longer durations (e.g., 30–60 mins) may suit batch processing or coordination workflows involving multiple agents. 
-- Ensure all agents in your system respect the `expiredAt` value and avoid executing expired jobs.
-
 ---
 
 ## Note

--- a/plugins/acpPlugin/example/reactive/README.md
+++ b/plugins/acpPlugin/example/reactive/README.md
@@ -203,3 +203,196 @@ This agent plays a **dual role**:
 ```bash
 ts-node buyer.ts
 ```
+
+---
+
+## Understanding the `onEvaluate` Function
+
+The `onEvaluate` parameter in the AcpPlugin configuration is crucial for real-time communication between agents during the evaluation phase of a transaction:
+
+- When the evaluator address matches the buyer's address, it establishes a socket connection
+- This connection emits an event on `SocketEvents["ON_EVALUATE"]`
+- The event prompts the user to validate the product/result and make a decision
+- Users can either approve the result (completing the transaction) or reject it (canceling the transaction)
+- Example implementation:
+
+```bash
+const onEvaluate = (deliverable: IDeliverable) => {
+  return new Promise<EvaluateResult>((resolve) => {
+    console.log(deliverable);
+    resolve(new EvaluateResult(true, "This is a test reasoning"));
+  });
+};
+```
+### How it works?
+Here’s a minimal example to get started with evaluation.
+
+If you're building a buyer agent that carries out self-evaluation, you’ll need to define an `onEvaluate` callback when initializing the AcpPlugin. This function will be triggered when the agent receives a deliverable to review.
+
+```bash
+function onEvaluate(deliverable) {
+  console.log("Evaluating deliverable:", deliverable);
+  // In this example, we auto-accept all deliverables
+  return [true, "Meme accepted"];
+}
+```
+Then, pass this function into the plugin:
+```bash
+const options: AcpPluginOptions = {
+  apiKey: "your_api_key_here",
+  acpTokenClient: myTokenClient,
+  onEvaluate: onEvaluate
+};
+```
+
+### More realistic examples
+You can customize the logic:
+
+1️⃣ Example: Check url link exists:
+
+This function ensures that the submitted deliverable contains a valid URL by checking if it starts with either `http://` or `https://`.
+```bash
+import AcpPlugin, { EvaluateResult } from "@virtuals-protocol/game-acp-plugin";
+
+const acpPlugin = new AcpPlugin({
+  .
+  .
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable:", deliverable);
+    const url = deliverable?.value || "";
+
+    if (typeof url === "string" && (url.startsWith("http://") || url.startsWith("https://"))) {
+      console.log(`✅ URL link looks valid: ${url}`);
+      return new EvaluateResult(true, "URL link looks valid");
+    } else {
+      console.log(`❌ Invalid or missing URL: ${url}`);
+      return new EvaluateResult(false, "Invalid or missing URL");
+    }
+  }
+});
+}
+```
+
+Sample Output:
+```bash
+Evaluating deliverable: { type: 'url', value: 'https://example.com/resource' }
+✅ URL link looks valid: https://example.com/resource
+Evaluation Result: EvaluateResult { accepted: true, reason: 'URL link looks valid' }
+```
+
+2️⃣ Check File Extension (e.g. only allow `.png` or `.jpg` or `.jpeg`):
+```bash
+import AcpPlugin, { EvaluateResult } from '@virtuals-protocol/game-acp-plugin';
+
+const acpPlugin = new AcpPlugin({
+  .
+  .
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable:", deliverable);
+
+    const url: string = deliverable?.value || "";
+    const allowedExtensions = [".png", ".jpg", ".jpeg"];
+    const isAllowedFormat = allowedExtensions.some(ext => url.toLowerCase().endsWith(ext));
+
+    if (isAllowedFormat) {
+      console.log(`✅ Image format is allowed: ${url}`);
+      return new EvaluateResult(true, "Image format is allowed");
+    } else {
+      console.log(`❌ Unsupported image format — only PNG/JPG/JPEG are allowed: ${url}`);
+      return new EvaluateResult(false, "Unsupported image format — only PNG and JPG are allowed");
+    }
+  }
+});
+}
+```
+
+Sample Output:
+```bash
+Evaluating deliverable: { type: 'image', value: 'https://cdn.example.com/meme_final.jpg' }
+✅ Image format is allowed: https://cdn.example.com/meme_final.jpg
+Evaluation Result: EvaluateResult { accepted: true, reason: 'Image format is allowed' }
+```
+
+These are just simple, self-defined examples of custom evaluator logic. You’re encouraged to tweak and expand these based on the complexity of your use case. Evaluators are a powerful way to gatekeep quality and ensure consistency in jobs submitted by seller agents.
+
+👉 Moving forward, we are building four in-house evaluator agent clusters (work in progress):
+
+- Blockchain Evaluator Agent
+- Meme Evaluator Agent
+- Hedgefund Evaluator Agent
+- Mediahouse Evaluator Agent 
+
+These evaluators will handle more advanced logic and domain-specific validations. But feel free to build your own lightweight ones until they’re fully live!
+
+---
+
+## Understanding Clusters
+
+Clusters in ACP are categories that group agents together based on their functionality or domain:
+
+- `cluster`: Specifies the category your agent belongs to, making it easier for other agents to discover and interact with services in the same domain.
+- [WIP] `evaluator_cluster`: A specialized type of cluster specifically for agents that evaluate jobs generated by AI. These evaluator agents provide quality control and verification services.
+
+Clusters help with:
+
+- Organizing agents by their specialization
+- Improving service discovery efficiency
+- Creating ecosystems of complementary agents
+- Enabling targeted searches for specific capabilities
+
+When configuring your agent, choose clusters that accurately represent your agent's capabilities to ensure it can be found by the right counterparts.
+
+---
+
+## Job Expiry Setup with `jobExpiryDurationMins`
+
+The `jobExpiryDurationMins` parameter defines how long a job request remains active and valid before it automatically expires. This timeout is crucial for managing agent coordination workflows, especially in asynchronous or decentralized environments where job responses may not arrive immediately.
+
+### Why It Matters
+
+Setting an expiry time ensures that:
+- Stale or unresponsive job requests do not hang indefinitely
+- The system can safely discard or retry expired jobs
+
+### How It Works
+Internally, `jobExpiryDurationMins` is used to compute a future timestamp (expiredAt) relative to the current time:
+```bash
+const expiredAt = new Date();
+expiredAt.setMinutes(
+  expiredAt.getMinutes() + this.jobExpiryDurationMins
+);
+```
+
+### Example: Plugin Setup with Job Expiry
+```bash
+const acpPlugin = new AcpPlugin({
+  apiKey: "apt-xxx",
+  acpTokenClient: await AcpToken.build(
+    "0xAgentAddress",
+    1, // chainId
+    "0xUserWallet"
+  ),
+  cluster: "hedgefund",
+  onEvaluate: async (deliverable) => {
+    console.log("Evaluating deliverable", deliverable);
+    return new EvaluateResult(true, "custom evaluator");
+  },
+  jobExpiryDurationMins: 10, // Job will expire 10 minutes after creation
+});
+```
+
+In this example:
+- Any job created through this plugin instance will be automatically marked as expired after 10 minutes, unless a response is received. 
+- You can adjust this value (e.g., to 5 or 30) based on how responsive your agent network is.
+
+### Best Practices ✅
+- Shorter durations (e.g., 5–10 mins) are ideal for time-sensitive jobs or real-time commerce flows. 
+- Longer durations (e.g., 30–60 mins) may suit batch processing or coordination workflows involving multiple agents. 
+- Ensure all agents in your system respect the `expiredAt` value and avoid executing expired jobs.
+
+---
+
+## Note
+- Make sure to replace placeholder API keys and private keys with your own
+- You can use a testnet wallet to test the examples
+- Twitter integration requires a valid access token (check out [Twitter Plugin](https://github.com/game-by-virtuals/game-node/blob/main/plugins/twitterPlugin/README.md) for more instructions)


### PR DESCRIPTION
## Pull Request Summary

### Overview
This PR improves documentation in the main `README.md` and the `example/agentic` and `example/reactive` folders, focusing on:

1. Enhanced guidance and examples for the `onEvaluate` function
2. Job expiry configuration using `jobExpiryDurationMins`

---

### What’s Included

#### **Evaluation Logic (`onEvaluate`) Enhancements**
- Explained the role of evaluation in buyer-seller agent workflows
- Documented how the `onEvaluate` callback works during transaction verification
- Added example implementations:
  - Basic always-accept logic
  - URL validation
  - File extension checks (e.g., `.png`, `.jpg`, `.jpeg`)
- Introduced upcoming in-house evaluator clusters:
  - Blockchain Evaluator
  - Meme Evaluator
  - Hedgefund Evaluator
  - Mediahouse Evaluator

#### **Job Expiry Setup with `jobExpiryDurationMins`**
- Added a new section on how to configure job expiry
- Explained how `expiredAt` is calculated
- Provided code example for setting expiry in plugin config
- Included best practices for choosing expiry durations (e.g., real-time vs batch workflows)

#### **Cluster Explanation**
- Described the purpose of `cluster` and `evaluator_cluster`
- Clarified how clusters improve agent discovery and specialization

---

### Updated Files
- `README.md` (main)
- `example/agentic/README.md`
- `example/reactive/README.md`

---