### PR TITLE
[acp plugin] fix: assign twitterClient from constructor options

### DIFF
--- a/plugins/acpPlugin/src/acpPlugin.ts
+++ b/plugins/acpPlugin/src/acpPlugin.ts
@@ -73,6 +73,7 @@ class AcpPlugin {
       options.agentRepoUrl
     );
     this.cluster = options.cluster;
+    this.twitterClient = options.twitterClient;
     this.evaluatorCluster = options.evaluatorCluster;
     this.onEvaluate = options.onEvaluate || this.defaultOnEvaluate;
     this.jobExpiryDurationMins = options.jobExpiryDurationMins || 1440;


### PR DESCRIPTION
Bug fix to get twitter client working properly
- earlier, this line didn't seem to work even when twitterClient is initialised
- Ensures that the twitterClient which passed to AcpPlugin is properly assigned
