### PR TITLE
feat: add Maiat Trust Score plugin

### DIFF
--- a/plugins/maiatTrustPlugin/README.md
+++ b/plugins/maiatTrustPlugin/README.md
@@ -1,0 +1,120 @@
+# @virtuals-protocol/game-maiat-plugin
+
+> Trust score verification for GAME agents — powered by [Maiat Protocol](https://maiat-protocol.vercel.app)
+
+Give your Virtuals agent the ability to **check trust before it acts**. Maiat Protocol provides on-chain verified trust scores for tokens, DeFi protocols, and AI agents on Base.
+
+## Why
+
+AI agents executing swaps autonomously can be exploited by:
+- Rug-pull tokens with no history
+- Honeypot contracts
+- Low-liquidity traps
+- Unverified counterparties
+
+Maiat trust scores are computed from verified reviews, on-chain activity, and AI analysis — stored in a `TrustScoreOracle` contract on Base.
+
+## Install
+
+```bash
+npm install @virtuals-protocol/game-maiat-plugin
+```
+
+## Quick Start
+
+```typescript
+import { GameAgent, GameWorkerService } from "@virtuals-protocol/game";
+import MaiatTrustPlugin from "@virtuals-protocol/game-maiat-plugin";
+
+const maiatPlugin = new MaiatTrustPlugin({
+  minScore: 3.0,   // reject tokens with score < 3.0/10
+  chain: "base",
+});
+
+const agent = new GameAgent(process.env.GAME_API_KEY!, {
+  name: "Trust-Gated Agent",
+  goal: "Execute swaps only for tokens with Maiat trust score ≥ 3.0",
+  workers: [new GameWorkerService(maiatPlugin.getWorker())],
+});
+
+await agent.init();
+await agent.step({ verbose: true });
+```
+
+## Functions
+
+### `check_trust_score`
+
+Query the trust score for any address or project name.
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| `identifier` | `string` | `0x...` address or project name (e.g. `"Uniswap"`, `"AIXBT"`) |
+| `chain` | `string` | Blockchain (default: `"base"`) |
+
+**Returns:**
+```json
+{
+  "address": "0x...",
+  "score": 8.7,
+  "risk": "low",
+  "type": "DeFi",
+  "flags": [],
+  "safe": true,
+  "summary": "Trust score for Uniswap: 8.7/10 | Risk: LOW | Safe: YES"
+}
+```
+
+---
+
+### `gate_swap`
+
+Check whether a swap is safe before executing. Checks both sides.
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| `token_in` | `string` | Token being sold |
+| `token_out` | `string` | Token being bought |
+| `min_score` | `number` | Minimum score to pass (default: `3.0`) |
+
+**Returns:** `APPROVED` or `REJECTED` with reasons.
+
+---
+
+### `batch_check_trust`
+
+Score multiple addresses at once, sorted by trust.
+
+| Arg | Type | Description |
+|-----|------|-------------|
+| `identifiers` | `string` | Comma-separated addresses or names (max 10) |
+
+## Configuration
+
+```typescript
+new MaiatTrustPlugin({
+  apiUrl: "https://maiat-protocol.vercel.app",  // default
+  apiKey: "your-api-key",                        // optional
+  minScore: 3.0,                                 // 0–10 scale
+  chain: "base",                                 // base | bnb | solana
+})
+```
+
+## Score Scale
+
+| Score | Risk | Meaning |
+|-------|------|---------|
+| 7–10 | 🟢 Low | Trusted, well-reviewed |
+| 4–6.9 | 🟡 Medium | Use with caution |
+| 0–3.9 | 🔴 High | Risky, avoid |
+
+## Links
+
+- 🌐 [maiat-protocol.vercel.app](https://maiat-protocol.vercel.app)
+- 📦 [GitHub](https://github.com/JhiNResH/maiat-protocol)
+- 🔗 Oracle contract (Base Sepolia): `0xF662902ca227BabA3a4d11A1Bc58073e0B0d1139`
+- 📖 [API docs](https://maiat-protocol.vercel.app/docs)
+
+## License
+
+MIT

--- a/plugins/maiatTrustPlugin/package.json
+++ b/plugins/maiatTrustPlugin/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@virtuals-protocol/game-maiat-plugin",
+  "version": "0.1.0",
+  "description": "Maiat Trust Score plugin for the GAME SDK — lets your Virtuals agent verify trust before swapping or transacting",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --dts --format cjs,esm --out-dir dist",
+    "example": "ts-node src/example.ts",
+    "test": "echo 'No tests yet' && exit 0"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "virtuals",
+    "game",
+    "maiat",
+    "trust-score",
+    "ai-agent",
+    "defi",
+    "web3",
+    "uniswap",
+    "base"
+  ],
+  "author": "JhiNResH <https://github.com/JhiNResH>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/game-by-virtuals/game-node"
+  },
+  "homepage": "https://maiat-protocol.vercel.app",
+  "dependencies": {
+    "@virtuals-protocol/game": "^0.1.4"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "dotenv": "^16.4.7",
+    "ts-node": "^10.9.2",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.3"
+  }
+}

--- a/plugins/maiatTrustPlugin/src/example.ts
+++ b/plugins/maiatTrustPlugin/src/example.ts
@@ -1,0 +1,45 @@
+/**
+ * @maiat/game-maiat-plugin — Example usage
+ *
+ * Before running:
+ *   1. npm install
+ *   2. Get a GAME API key from https://console.game.virtuals.io
+ *   3. Set GAME_API_KEY in your environment (optional: MAIAT_API_KEY)
+ */
+import { GameAgent } from "@virtuals-protocol/game";
+import MaiatTrustPlugin from "./maiatTrustPlugin";
+import * as dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+  // 1. Init plugin
+  const maiatPlugin = new MaiatTrustPlugin({
+    minScore: 3.0,      // reject anything below 3.0/10
+    chain: "base",
+    // apiKey: process.env.MAIAT_API_KEY,   // optional — for higher rate limits
+  });
+
+  // 2. Create worker
+  const worker = maiatPlugin.getWorker();
+
+  // 3. Attach to a GAME agent
+  const agent = new GameAgent(process.env.GAME_API_KEY!, {
+    name: "TrustGated Trading Agent",
+    goal: "Execute token swaps only after verifying trust scores via Maiat Protocol. Reject any swap involving tokens with trust score below 3.0/10.",
+    description: "A DeFi trading agent that uses Maiat trust scoring to avoid rugs and scams.",
+    workers: [worker],
+  });
+
+  await agent.init();
+
+  // 4. Run examples
+  console.log("\n=== Example 1: Check trust score ===");
+  await agent.step({ verbose: true });
+
+  console.log("\n=== Example 2: Gate a swap ===");
+  // The agent will call gate_swap before executing
+  await agent.step({ verbose: true });
+}
+
+main().catch(console.error);

--- a/plugins/maiatTrustPlugin/src/index.ts
+++ b/plugins/maiatTrustPlugin/src/index.ts
@@ -1,0 +1,2 @@
+export { default as MaiatTrustPlugin } from "./maiatTrustPlugin";
+export type { IMaiatTrustPluginOptions, TrustResponse } from "./maiatTrustPlugin";

--- a/plugins/maiatTrustPlugin/src/maiatTrustPlugin.ts
+++ b/plugins/maiatTrustPlugin/src/maiatTrustPlugin.ts
@@ -1,0 +1,364 @@
+import {
+  GameWorker,
+  GameFunction,
+  ExecutableGameFunctionResponse,
+  ExecutableGameFunctionStatus,
+} from "@virtuals-protocol/game";
+
+// ─────────────────────────────────────────────
+//  Config
+// ─────────────────────────────────────────────
+
+const DEFAULT_API_URL = "https://maiat-protocol.vercel.app";
+const DEFAULT_MIN_SCORE = 3.0; // 0–10 scale
+const DEFAULT_CHAIN = "base";
+
+interface IMaiatTrustPluginOptions {
+  id?: string;
+  name?: string;
+  description?: string;
+  apiUrl?: string;
+  apiKey?: string;
+  minScore?: number;
+  chain?: string;
+}
+
+interface TrustResponse {
+  address: string;
+  score: number;
+  risk: "low" | "medium" | "high" | "unknown";
+  type: string;
+  flags: string[];
+  safe: boolean;
+  source: string;
+}
+
+// ─────────────────────────────────────────────
+//  API client
+// ─────────────────────────────────────────────
+
+async function fetchTrustScore(
+  identifier: string,
+  apiUrl: string,
+  chain: string,
+  apiKey?: string
+): Promise<TrustResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "User-Agent": "game-maiat-plugin/0.1.0",
+  };
+  if (apiKey) headers["Authorization"] = `Bearer ${apiKey}`;
+
+  // Try address-based lookup first, fall back to name search
+  const isAddress = /^0x[0-9a-fA-F]{40}$/.test(identifier);
+  const url = isAddress
+    ? `${apiUrl}/api/v1/score/${identifier}?chain=${chain}`
+    : `${apiUrl}/api/v1/trust-score`;
+
+  const res = await fetch(url, {
+    method: isAddress ? "GET" : "POST",
+    headers,
+    body: isAddress ? undefined : JSON.stringify({ projectName: identifier }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Maiat API error: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json() as Record<string, any>;
+
+  // Normalise both API response shapes
+  if (isAddress && data["score"] !== undefined) {
+    return {
+      address: identifier,
+      score: data["score"] as number,
+      risk: data["riskLevel"] ?? scoreToRisk(data["score"] as number),
+      type: data["type"] ?? "unknown",
+      flags: data["flags"] ?? [],
+      safe: (data["score"] as number) >= DEFAULT_MIN_SCORE,
+      source: data["source"] ?? "maiat",
+    };
+  }
+
+  // POST /api/v1/trust-score response shape
+  const score = (data["trustScore"] as Record<string, any>)?.["overall"] ?? 0;
+  return {
+    address: identifier,
+    score: score / 10, // convert 0–100 to 0–10
+    risk: scoreToRisk(score / 10),
+    type: (data["project"] as Record<string, any>)?.["category"] ?? "unknown",
+    flags: [],
+    safe: score / 10 >= DEFAULT_MIN_SCORE,
+    source: "maiat",
+  };
+}
+
+function scoreToRisk(score: number): "low" | "medium" | "high" | "unknown" {
+  if (score >= 7) return "low";
+  if (score >= 4) return "medium";
+  if (score >= 0) return "high";
+  return "unknown";
+}
+
+// ─────────────────────────────────────────────
+//  Plugin class
+// ─────────────────────────────────────────────
+
+class MaiatTrustPlugin {
+  private id: string;
+  private name: string;
+  private description: string;
+  private apiUrl: string;
+  private apiKey?: string;
+  private minScore: number;
+  private chain: string;
+
+  constructor(options: IMaiatTrustPluginOptions = {}) {
+    this.id = options.id ?? "maiat_trust_worker";
+    this.name = options.name ?? "Maiat Trust Score Worker";
+    this.description =
+      options.description ??
+      "Queries Maiat Protocol for trust scores of on-chain addresses, tokens, " +
+        "DeFi protocols, and AI agents. Use before executing any swap, transfer, " +
+        "or interaction to assess counterparty risk.";
+    this.apiUrl = options.apiUrl ?? DEFAULT_API_URL;
+    this.apiKey = options.apiKey;
+    this.minScore = options.minScore ?? DEFAULT_MIN_SCORE;
+    this.chain = options.chain ?? DEFAULT_CHAIN;
+  }
+
+  public getWorker(data?: {
+    functions?: GameFunction<any>[];
+    getEnvironment?: () => Promise<Record<string, any>>;
+  }): GameWorker {
+    return new GameWorker({
+      id: this.id,
+      name: this.name,
+      description: this.description,
+      functions: data?.functions ?? [
+        this.checkTrustScore,
+        this.gateSwap,
+        this.batchCheckTrust,
+      ],
+      getEnvironment: data?.getEnvironment,
+    });
+  }
+
+  // ── Function 1: check_trust_score ─────────────
+  get checkTrustScore() {
+    return new GameFunction({
+      name: "check_trust_score",
+      description:
+        "Query the Maiat trust score for an on-chain address, token, DeFi protocol, " +
+        "or AI agent. Returns a score (0–10), risk level, and any warning flags. " +
+        "Use this before interacting with an unknown address or protocol.",
+      args: [
+        {
+          name: "identifier",
+          description:
+            "Ethereum/Base address (0x...) OR project/agent name (e.g. 'Uniswap', 'AIXBT').",
+          type: "string",
+        },
+        {
+          name: "chain",
+          description: "Blockchain to query. Defaults to 'base'.",
+          type: "string",
+          optional: true,
+        },
+      ] as const,
+      executable: async (args: any, logger: any) => {
+        try {
+          if (!args.identifier) {
+            return new ExecutableGameFunctionResponse(
+              ExecutableGameFunctionStatus.Failed,
+              "identifier is required (address or project name)"
+            );
+          }
+
+          const chain = args.chain ?? this.chain;
+          logger(`[Maiat] Checking trust score for: ${args.identifier} on ${chain}`);
+
+          const result = await fetchTrustScore(
+            args.identifier,
+            this.apiUrl,
+            chain,
+            this.apiKey
+          );
+
+          const summary =
+            `Trust score for ${args.identifier}: ${result.score.toFixed(1)}/10 ` +
+            `| Risk: ${result.risk.toUpperCase()} ` +
+            `| Safe: ${result.safe ? "YES" : "NO"} ` +
+            (result.flags.length ? `| Flags: ${result.flags.join(", ")}` : "");
+
+          logger(`[Maiat] ${summary}`);
+
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Done,
+            JSON.stringify({ ...result, summary })
+          );
+        } catch (e: any) {
+          logger(`[Maiat] Error: ${e.message}`);
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Failed,
+            `Failed to query trust score: ${e.message}`
+          );
+        }
+      },
+    });
+  }
+
+  // ── Function 2: gate_swap ─────────────────────
+  get gateSwap() {
+    return new GameFunction({
+      name: "gate_swap",
+      description:
+        "Check whether a swap is safe to execute based on Maiat trust scores for " +
+        "both the input and output tokens. Returns APPROVED or REJECTED with reasons. " +
+        "Always call this before executing a token swap.",
+      args: [
+        {
+          name: "token_in",
+          description: "Address or name of the token being sold (input token).",
+          type: "string",
+        },
+        {
+          name: "token_out",
+          description: "Address or name of the token being bought (output token).",
+          type: "string",
+        },
+        {
+          name: "min_score",
+          description: `Minimum trust score required (0–10). Defaults to ${DEFAULT_MIN_SCORE}.`,
+          type: "number",
+          optional: true,
+        },
+      ] as const,
+      executable: async (args: any, logger: any) => {
+        try {
+          if (!args.token_in || !args.token_out) {
+            return new ExecutableGameFunctionResponse(
+              ExecutableGameFunctionStatus.Failed,
+              "Both token_in and token_out are required"
+            );
+          }
+
+          const minScore = args.min_score ?? this.minScore;
+          logger(`[Maiat] Gating swap: ${args.token_in} → ${args.token_out} (min score: ${minScore})`);
+
+          const [scoreIn, scoreOut] = await Promise.all([
+            fetchTrustScore(args.token_in, this.apiUrl, this.chain, this.apiKey),
+            fetchTrustScore(args.token_out, this.apiUrl, this.chain, this.apiKey),
+          ]);
+
+          const rejected: string[] = [];
+          if (scoreIn.score < minScore) {
+            rejected.push(
+              `${args.token_in} score ${scoreIn.score.toFixed(1)} < ${minScore} (risk: ${scoreIn.risk})`
+            );
+          }
+          if (scoreOut.score < minScore) {
+            rejected.push(
+              `${args.token_out} score ${scoreOut.score.toFixed(1)} < ${minScore} (risk: ${scoreOut.risk})`
+            );
+          }
+
+          if (rejected.length > 0) {
+            const reason = `REJECTED: ${rejected.join("; ")}`;
+            logger(`[Maiat] ${reason}`);
+            return new ExecutableGameFunctionResponse(
+              ExecutableGameFunctionStatus.Failed,
+              reason
+            );
+          }
+
+          const approval =
+            `APPROVED: ${args.token_in} (${scoreIn.score.toFixed(1)}/10) → ` +
+            `${args.token_out} (${scoreOut.score.toFixed(1)}/10) — both pass threshold`;
+          logger(`[Maiat] ${approval}`);
+
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Done,
+            JSON.stringify({
+              approved: true,
+              token_in: scoreIn,
+              token_out: scoreOut,
+              message: approval,
+            })
+          );
+        } catch (e: any) {
+          logger(`[Maiat] Error: ${e.message}`);
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Failed,
+            `Failed to gate swap: ${e.message}`
+          );
+        }
+      },
+    });
+  }
+
+  // ── Function 3: batch_check_trust ─────────────
+  get batchCheckTrust() {
+    return new GameFunction({
+      name: "batch_check_trust",
+      description:
+        "Check trust scores for multiple addresses or project names at once. " +
+        "Returns a ranked list with risk levels. Useful for comparing options before trading.",
+      args: [
+        {
+          name: "identifiers",
+          description: "Comma-separated list of addresses or project names.",
+          type: "string",
+        },
+      ] as const,
+      executable: async (args: any, logger: any) => {
+        try {
+          if (!args.identifiers) {
+            return new ExecutableGameFunctionResponse(
+              ExecutableGameFunctionStatus.Failed,
+              "identifiers is required (comma-separated list)"
+            );
+          }
+
+          const ids = args.identifiers
+            .split(",")
+            .map((s: string) => s.trim())
+            .filter(Boolean)
+            .slice(0, 10); // max 10
+
+          logger(`[Maiat] Batch checking ${ids.length} identifiers`);
+
+          const results = await Promise.allSettled(
+            ids.map((id: string) =>
+              fetchTrustScore(id, this.apiUrl, this.chain, this.apiKey)
+            )
+          );
+
+          const scores = results.map((r, i) =>
+            r.status === "fulfilled"
+              ? r.value
+              : { address: ids[i], score: 0, risk: "unknown", safe: false, error: (r as any).reason?.message }
+          );
+
+          // Sort by score descending
+          scores.sort((a: any, b: any) => b.score - a.score);
+
+          logger(`[Maiat] Batch complete. Top: ${scores[0]?.address} (${scores[0]?.score?.toFixed(1)}/10)`);
+
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Done,
+            JSON.stringify({ count: scores.length, results: scores })
+          );
+        } catch (e: any) {
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Failed,
+            `Batch check failed: ${e.message}`
+          );
+        }
+      },
+    });
+  }
+}
+
+export { MaiatTrustPlugin, IMaiatTrustPluginOptions, TrustResponse };
+export default MaiatTrustPlugin;

--- a/plugins/maiatTrustPlugin/tsconfig.json
+++ b/plugins/maiatTrustPlugin/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Maiat Trust Score Plugin

Adds **trust score verification** to GAME agents via [Maiat Protocol](https://maiat-protocol.vercel.app) — an on-chain trust layer for agentic commerce on Base.

### Why this plugin matters

AI agents executing autonomous swaps face a real risk: they can't inherently tell if a token is a rug, honeypot, or scam. Maiat provides **verified trust scores** from:
- On-chain activity analysis
- AI-verified community reviews
- `TrustScoreOracle` contract on Base Sepolia

### Functions

| Function | Description |
|----------|-------------|
| `check_trust_score` | Query trust score (0–10) for any address or project name |
| `gate_swap` | Check both sides of a swap before executing — rejects if below threshold |
| `batch_check_trust` | Score up to 10 addresses at once, ranked by trust |

### Usage

```typescript
import MaiatTrustPlugin from '@virtuals-protocol/game-maiat-plugin';

const plugin = new MaiatTrustPlugin({ minScore: 3.0, chain: 'base' });

const agent = new GameAgent(GAME_API_KEY, {
  goal: 'Execute swaps only for tokens with trust score ≥ 3.0/10',
  workers: [plugin.getWorker()],
});
```

### Technical

- Zero external SDK dependencies (pure fetch calls to Maiat REST API)
- TypeScript + CJS/ESM dual build
- Follows same structure as `coingeckoMaopPlugin`
- API is free tier (100 req/day), optional API key for unlimited

### Links
- Live API: https://maiat-protocol.vercel.app/docs
- GitHub: https://github.com/JhiNResH/maiat-protocol
- Oracle (Base Sepolia): `0xF662902ca227BabA3a4d11A1Bc58073e0B0d1139`