### PR TITLE
Add get_followers function to Twitter plugin

### DIFF
--- a/plugins/twitterPlugin/src/twitterPlugin.ts
+++ b/plugins/twitterPlugin/src/twitterPlugin.ts
@@ -43,6 +43,7 @@ class TwitterPlugin {
         this.postTweetFunction,
         this.likeTweetFunction,
         this.quoteTweetFunction,
+        this.getFollowersFunction,
       ],
       getEnvironment: data?.getEnvironment || this.getMetrics.bind(this),
     });
@@ -214,6 +215,59 @@ class TwitterPlugin {
           return new ExecutableGameFunctionResponse(
             ExecutableGameFunctionStatus.Failed,
             "Failed to like tweet"
+          );
+        }
+      },
+    });
+  }
+
+  get getFollowersFunction() {
+    return new GameFunction({
+      name: "get_followers",
+      description:
+        "Retrieve the list of followers for a given user ID. Use this to analyze a user's audience or find potential accounts to engage with.",
+      args: [
+        { name: "user_id", description: "The Twitter user ID to get followers for" },
+      ] as const,
+      executable: async (args, logger) => {
+        try {
+          if (!args.user_id) {
+            return new ExecutableGameFunctionResponse(
+              ExecutableGameFunctionStatus.Failed,
+              "User ID is required"
+            );
+          }
+
+          logger(`Getting followers for user id: ${args.user_id}`);
+
+          const followers = await this.twitterClient.v2.followers(args.user_id, {
+            max_results: 100,
+            "user.fields": ["public_metrics", "description"],
+          });
+
+          const feedbackMessage =
+            "Followers found:\n" +
+            JSON.stringify(
+              followers.data.data.map((user) => ({
+                userId: user.id,
+                username: user.username,
+                name: user.name,
+                description: user.description,
+                followers: user.public_metrics?.followers_count,
+                following: user.public_metrics?.following_count,
+              }))
+            );
+
+          logger(feedbackMessage);
+
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Done,
+            feedbackMessage
+          );
+        } catch (e) {
+          return new ExecutableGameFunctionResponse(
+            ExecutableGameFunctionStatus.Failed,
+            "Failed to get followers"
           );
         }
       },

--- a/plugins/twitterPlugin/src/twitterPlugin.ts
+++ b/plugins/twitterPlugin/src/twitterPlugin.ts
@@ -248,7 +248,7 @@ class TwitterPlugin {
           const feedbackMessage =
             "Followers found:\n" +
             JSON.stringify(
-              followers.data.data.map((user) => ({
+              followers.data.map((user: any) => ({
                 userId: user.id,
                 username: user.username,
                 name: user.name,


### PR DESCRIPTION
## Description
Adds a new `get_followers` function to the Twitter plugin that allows retrieving and analyzing a user's followers list.

## Changes
- Added `getFollowersFunction` getter method that creates a new GameFunction
- Registers the function in the plugin's function list
- The function accepts a `user_id` parameter and retrieves up to 100 followers with their public metrics and descriptions
- Returns formatted follower data including username, name, description, follower count, and following count
- Includes proper error handling and logging

## Use Cases
- Analyze a user's audience composition
- Identify potential accounts to engage with
- Support audience research and engagement strategies

## Test Plan
Existing plugin tests should pass. The function follows the same pattern as other Twitter API functions in the plugin (postTweet, likeTweet, quoteTweet).

https://claude.ai/code/session_01KUvwzoZhwrUhv6Z2vt8ors